### PR TITLE
fix: ios name error ITSM-90129

### DIFF
--- a/remote/ios/Runner/Info.plist
+++ b/remote/ios/Runner/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>remote</string>
+	<string>RealtimeKit</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
This changes the app name from remote -> RealtimeKit
https://stackoverflow.com/questions/46694153/changing-the-project-name